### PR TITLE
new from-name keyword argument to send-letter

### DIFF
--- a/smtp.cl
+++ b/smtp.cl
@@ -162,6 +162,7 @@ v5: rm stray force-output of t; send-smtp-1: New external-format keyword arg."
 
 (defun send-letter (server from to message
 		    &key cc bcc subject reply-to headers
+                         from-name
 			 login password attachments)
   ;;
   ;; see documentation at the head of this file
@@ -215,7 +216,7 @@ message must be a string, stream, or mime-part-constructed, not ~s" message))))
 	  
 	  ;; Give priority to headers already provided in a mime-part.
 	  (if* (not (already-have "From"))
-	     then (format hdrs "From: ~a~%" from))
+	     then (format hdrs "From: ~:[~a~;~:*~a <~a>~]~%" from-name from))
 	
 	  (if* (not (already-have "To"))
 	     then (format hdrs "To: ~a~%" (list-to-delimited-string tos ", ")))


### PR DESCRIPTION
If from-name is specified, the generated From: header of the email
will be have the form "from-name <from>" rather than just "from".
